### PR TITLE
Installed Bootstrap Icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "packages": {
         "": {
             "dependencies": {
+                "bootstrap-icons": "^1.11.3",
                 "popper.js": "^1.16.1"
             },
             "devDependencies": {
@@ -973,6 +974,22 @@
             "peerDependencies": {
                 "@popperjs/core": "^2.11.8"
             }
+        },
+        "node_modules/bootstrap-icons": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
+            "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/twbs"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/bootstrap"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/braces": {
             "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "vite": "^5.0"
     },
     "dependencies": {
+        "bootstrap-icons": "^1.11.3",
         "popper.js": "^1.16.1"
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,2 @@
 import './bootstrap';
+import 'bootstrap-icons/font/bootstrap-icons.css';

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -10,7 +10,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
     {{-- Link the Bootstrap Icons CDN --}}
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.11.0/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 
     {{-- Link the compiled CSS and JS using Vite --}}
     @vite(['resources/js/app.js', 'resources/sass/app.scss'])

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,6 +9,9 @@
     <script src="https://kit.fontawesome.com/b4bcada09d.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
+    {{-- Link the Bootstrap Icons CDN --}}
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.11.0/font/bootstrap-icons.min.css" rel="stylesheet">
+
     {{-- Link the compiled CSS and JS using Vite --}}
     @vite(['resources/js/app.js', 'resources/sass/app.scss'])
 

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -10,7 +10,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
     {{-- Link the Bootstrap Icons CDN --}}
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.11.0/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 
     {{-- Link the compiled CSS and JS using Vite --}}
     @vite(['resources/js/app.js', 'resources/sass/app.scss'])

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -9,6 +9,9 @@
     <script src="https://kit.fontawesome.com/b4bcada09d.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
+    {{-- Link the Bootstrap Icons CDN --}}
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.11.0/font/bootstrap-icons.min.css" rel="stylesheet">
+
     {{-- Link the compiled CSS and JS using Vite --}}
     @vite(['resources/js/app.js', 'resources/sass/app.scss'])
 


### PR DESCRIPTION
- Installed Bootstrap icons version 1.11.3 and updated dependencies.
- Added a new line "import 'bootstrap-icons/font/bootstrap-icons.css';" for resource/js/app.js.
- Linked Bootstrap Icons CDN links for app.blade.php and default.blade.php.